### PR TITLE
Fix Vercel Deployment

### DIFF
--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -32,6 +32,5 @@ export default defineConfig(({ mode }) => {
         resolve(__dirname, "test/setup/resizeObserverMock.ts"),
       ],
     },
-    base: mode === "production" ? "/vechain-dapp-kit/react/" : "/",
   };
 });


### PR DESCRIPTION
My Vercel deployment finally worked after removing the line:
    base: mode === "production" ? "/vechain-dapp-kit/react/" : "/",

Found out by consulting VeChain mentors at the EasyA VeChain hackathon.