### PR TITLE
Add quick start example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ dist-ssr
 server/dist
 public/dist
 .idea
+.yarn
+.pnp.*js

--- a/QuickStart.md
+++ b/QuickStart.md
@@ -4,7 +4,7 @@ Get a local development environment up and running with as few steps as possible
 
 ## Required Variables
 
-- **OPENAI_API_KEY:** [Get your GPT-4 OpenAI key](https://platform.openai.com/api-keys)
+- **OPENAI_API_KEY:** An OpenAI API key needs to be obtained manually from [OpenAI](https://platform.openai.com/api-keys):
 
 ## Start
 
@@ -14,12 +14,8 @@ yarn install
 yarn contracts:solo-up
 yarn contracts:deploy:solo
 
-PORT=3000 \
- ORIGIN="*" \
- OPENAI_API_KEY="sk-proj-.." \
+OPENAI_API_KEY="" \
  ADMIN_MNEMONIC="denial kitchen pet squirrel other broom bar gas better priority spoil cross" \
- NETWORK_URL=http://localhost:8669 \
- REWARD_AMOUNT=1 \
  yarn dev
 ```
 

--- a/QuickStart.md
+++ b/QuickStart.md
@@ -1,0 +1,41 @@
+# Development Environment 
+
+Get a local development environment up and running with as few steps as possible.
+
+## Required Variables
+
+- **OPENAI_API_KEY:** [Get your GPT-4 OpenAI key](https://platform.openai.com/api-keys)
+
+## Start
+
+```shell
+yarn set version classic
+yarn install
+yarn contracts:solo-up
+yarn contracts:deploy:solo
+
+PORT=3000 \
+ ORIGIN="*" \
+ OPENAI_API_KEY="sk-proj-.." \
+ ADMIN_MNEMONIC="denial kitchen pet squirrel other broom bar gas better priority spoil cross" \
+ NETWORK_URL=http://localhost:8669 \
+ REWARD_AMOUNT=1 \
+ yarn dev
+```
+
+## Result
+
+Link | Service 
+--- | ---
+http://localhost:8082 | Frontend
+http://localhost:3000 | Backend
+http://localhost:8081 | Inspector
+http://localhost:8669 | Solo Thor
+
+Deployed contracts documented in: [packages/config-contract/config.ts](packages/config-contract/config.ts)
+
+## Shutdown
+
+```shell
+yarn contracts:solo-down
+```

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@
                                   ##############
                                   #########
 
+> [!TIP]
+> Impatient? Check out the [QuickStart](./QuickStart.md) to instantly run the app template.
+
 Unlock the potential of decentralized application development on Vechain with our X-App template for VeBetterDAO. Designed for the Vechain Thor blockchain, this template integrates cutting-edge technologies such as React, TypeScript, Hardhat, and Express, ensuring a seamless and efficient DApp development experience. 🌟
 
 Read more about the implementation and key features of this template in our [Developer Docs](https://docs.vebetterdao.org/developer-guides/integration-examples/pattern-2-use-smart-contracts-and-backend).

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ yarn contracts:deploy:solo
 Once the deployment is completed successfully you can go ahead and start the frontend and backend:
 
 > ⚠️ **Warning:**
-> Remeber to set the OPENAI_API_KEY env variable in the backend .env.development.local file. Refer to the [Environment Variables](#environment-variables) section for more information.
+> Remember to set the OPENAI_API_KEY env variable in the backend .env.development.local file. Refer to the [Environment Variables](#environment-variables) section for more information.
 
 ```bash
 yarn dev

--- a/apps/backend/src/config/index.ts
+++ b/apps/backend/src/config/index.ts
@@ -1,13 +1,17 @@
 import { config } from 'dotenv';
 import { mnemonic } from '@vechain/sdk-core';
+import { ValidateEnv } from '@utils/validateEnv';
 config({ path: `.env.${process.env.NODE_ENV || 'development'}.local` });
 
+const validatedEnv = ValidateEnv();
+
 export const CREDENTIALS = process.env.CREDENTIALS === 'true';
-export const { NODE_ENV, PORT, LOG_FORMAT, LOG_DIR, ORIGIN } = process.env;
-export const { OPENAI_API_KEY } = process.env;
-export const { MAX_FILE_SIZE } = process.env;
-export const { ADMIN_MNEMONIC, ADMIN_ADDRESS } = process.env;
-export const { NETWORK_URL, NETWORK_TYPE } = process.env;
-export const { REWARD_AMOUNT } = process.env;
+export const { NODE_ENV, PORT, LOG_FORMAT, LOG_DIR, ORIGIN } = validatedEnv;
+
+export const { OPENAI_API_KEY } = validatedEnv;
+export const { MAX_FILE_SIZE } = validatedEnv;
+export const { ADMIN_MNEMONIC, ADMIN_ADDRESS } = validatedEnv;
+export const { NETWORK_URL, NETWORK_TYPE } = validatedEnv;
+export const { REWARD_AMOUNT } = validatedEnv;
 
 export const ADMIN_PRIVATE_KEY = mnemonic.derivePrivateKey(ADMIN_MNEMONIC.split(' '));

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -1,9 +1,6 @@
 import { App } from '@/app';
-import { ValidateEnv } from '@utils/validateEnv';
 import { initializeOpenAI } from './utils/initializeOpenAI';
 import { SubmissionRoute } from './routes/submission.route';
-
-ValidateEnv();
 
 export const openAIHelper = initializeOpenAI();
 

--- a/apps/backend/src/utils/logger.ts
+++ b/apps/backend/src/utils/logger.ts
@@ -5,7 +5,7 @@ import winstonDaily from 'winston-daily-rotate-file';
 import { LOG_DIR } from '../config';
 
 // logs dir
-const logDir: string = join(__dirname, LOG_DIR);
+const logDir: string = join(__dirname, LOG_DIR ?? '../logs');
 
 if (!existsSync(logDir)) {
   mkdirSync(logDir);

--- a/apps/backend/src/utils/logger.ts
+++ b/apps/backend/src/utils/logger.ts
@@ -5,7 +5,7 @@ import winstonDaily from 'winston-daily-rotate-file';
 import { LOG_DIR } from '../config';
 
 // logs dir
-const logDir: string = join(__dirname, LOG_DIR ?? '../logs');
+const logDir: string = join(__dirname, LOG_DIR);
 
 if (!existsSync(logDir)) {
   mkdirSync(logDir);

--- a/apps/backend/src/utils/validateEnv.ts
+++ b/apps/backend/src/utils/validateEnv.ts
@@ -1,8 +1,26 @@
-import { cleanEnv, port, str } from 'envalid';
+import { makeValidator, cleanEnv, port, str } from 'envalid';
+
+const openApiKey = makeValidator((apiKey: string) => {
+  if (/^sk-proj-.{100,}$/.test(apiKey)) {
+    return apiKey;
+  } else {
+    throw new Error('Please obtain a valid OpenAPI-Key from https://platform.openai.com/api-keys');
+  }
+});
 
 export const ValidateEnv = () => {
-  cleanEnv(process.env, {
+  return cleanEnv(process.env, {
     NODE_ENV: str(),
-    PORT: port(),
+    PORT: port({ devDefault: 3000 }),
+    ORIGIN: str({ devDefault: '*' }),
+    LOG_FORMAT: str({ devDefault: 'prod' }),
+    LOG_DIR: str({ devDefault: '../logs' }),
+    REWARD_AMOUNT: str({ devDefault: '1' }),
+    ADMIN_MNEMONIC: str(),
+    NETWORK_URL: str({ devDefault: 'http://localhost:8669' }),
+    NETWORK_TYPE: str({ devDefault: 'solo' }),
+    OPENAI_API_KEY: openApiKey(),
+    MAX_FILE_SIZE: str({ devDefault: '10mb' }),
+    ADMIN_ADDRESS: str({ default: '' }),
   });
 };


### PR DESCRIPTION
This PR aims to simplify the start for impatient developers on the app template:

- Adds a `QuickStart.md` with reduced information and a single snippet to get started
- Documents the links that will be available
- Defaults the log dir, to use less config variables